### PR TITLE
IOS-11535: Check the code compatibility with iOS 18

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.5
 import PackageDescription
 
 let package = Package(
@@ -20,7 +20,13 @@ let package = Package(
             path: "SocketRocket",
             publicHeadersPath: "PublicHeaders",
             cSettings: [
-                .headerSearchPath("Internal/**"),
+                .headerSearchPath("Internal"),
+                .headerSearchPath("Internal/Delegate"),
+                .headerSearchPath("Internal/IOConsumer"),
+                .headerSearchPath("Internal/Proxy"),
+                .headerSearchPath("Internal/RunLoop"),
+                .headerSearchPath("Internal/Security"),
+                .headerSearchPath("Internal/Utilities"),
             ]
         ),
     ]


### PR DESCRIPTION
# Ticket
JIRA ticket: https://tophat.atlassian.net/browse/IOS-11535

# Description
In Xcode 16.0 and 16.1, the following line in `Package.swift` no longer works: `.headerSearchPath("Internal/**"),`.
As a workaround, I had to explicitly specify all subfolders of the `Internal` folder.
It looks like a bug and maybe fixed by Apple latter.